### PR TITLE
Fix the signInUser mutation and propagated error sources

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.use(
   bodyParser.json(),
   graphqlExpress(buildOptions),
 );
-// fix the options before deploying
+
 app.use(
   '/graphiql',
   graphiqlExpress({

--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.use(
   bodyParser.json(),
   graphqlExpress(buildOptions),
 );
-
+// fix the options before deploying
 app.use(
   '/graphiql',
   graphiqlExpress({

--- a/models/user.js
+++ b/models/user.js
@@ -87,7 +87,7 @@ module.exports = (sequelize, DataTypes) => {
 
   User.hashPassword = async password => bcrypt.hash(password, 12);
 
-  User.prototype.checkPassword = async password => bcrypt.compare(password, this.password);
+  User.prototype.checkPassword = async (password, current_user) => bcrypt.compare(password, current_user.password);
 
   User.associate = (models) => {
     User.belongsTo(models.Country);

--- a/models/user.js
+++ b/models/user.js
@@ -87,7 +87,7 @@ module.exports = (sequelize, DataTypes) => {
 
   User.hashPassword = async password => bcrypt.hash(password, 12);
 
-  User.prototype.checkPassword = async (password, current_user) => bcrypt.compare(password, current_user.password);
+  User.prototype.checkPassword = async (password, user) => bcrypt.compare(password, user.password);
 
   User.associate = (models) => {
     User.belongsTo(models.Country);

--- a/models/user.js
+++ b/models/user.js
@@ -87,7 +87,10 @@ module.exports = (sequelize, DataTypes) => {
 
   User.hashPassword = async password => bcrypt.hash(password, 12);
 
-  User.prototype.checkPassword = async (password, user) => bcrypt.compare(password, user.password);
+  User.prototype.checkPassword = function async(password) {
+    console.log(this.password);
+    return bcrypt.compare(password, this.password);
+  };
 
   User.associate = (models) => {
     User.belongsTo(models.Country);

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -65,8 +65,8 @@ module.exports = {
     },
 
     signInUser: async (root, { email, password }, { models: { User } }) => {
-      const user = await User.findOne({ email });
-      if (!user || !user.checkPassword(password)) throw new Error('Invalid email or password.');
+      const user = await User.findOne({ where: { email } });
+      if (!user || !await user.checkPassword(password, user)) throw new Error('Invalid email or password.');
       return {
         jwt: await jwt.sign({
           user_role: user.role,

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -66,7 +66,7 @@ module.exports = {
 
     signInUser: async (root, { email, password }, { models: { User } }) => {
       const user = await User.findOne({ where: { email } });
-      if (!user || !await user.checkPassword(password, user)) throw new Error('Invalid email or password.');
+      if (!user || !await user.checkPassword(password)) throw new Error('Invalid email or password.');
       return {
         jwt: await jwt.sign({
           user_role: user.role,


### PR DESCRIPTION
SCHEMA/RESOLVERS.JS:

    ln 68: findOne was raising an error indicating that options.where was
    missing. fixed to now properly select a user where email matches

    ln 69: user.checkPassword() instance method returns a promise. it needed to
    be awaited to properly make use of the expected boolean

MODELS/USER.JS:

```
ln 90: checkPassword() was raising an error signifying that invalid
inputs were being passed to the bcrypt.compare() method. it was
displayed as STRING, UNDEFINED indicating that the 'this' keyword was
failing within the instance method. 

modified the checkPassword method to
accept a current_user parameter which is passed as the user instance
generated in the resolver. this provides the expected 'this'
functionality - no pun intended...
```