### PR TITLE
Update cohort team model #179

### DIFF
--- a/migrations/20171128084243-autobot_cohort_team_update.js
+++ b/migrations/20171128084243-autobot_cohort_team_update.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('cohort_teams', 'slack_channel_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('cohort_teams', 'slack_channel_id');
+  },
+};

--- a/migrations/20171128084243-autobot_cohort_team_update.js
+++ b/migrations/20171128084243-autobot_cohort_team_update.js
@@ -1,12 +1,8 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('cohort_teams', 'slack_channel_id', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-  },
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('cohort_teams', 'slack_channel_id', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  }),
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn('cohort_teams', 'slack_channel_id');
-  },
+  down: queryInterface => queryInterface.removeColumn('cohort_teams', 'slack_channel_id'),
 };

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -44,6 +44,11 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+
+    slack_channel_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   });
 
   CohortTeam.associate = (models) => {

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -35,6 +35,11 @@ module.exports = (sequelize, DataTypes) => {
       },
     },
 
+    slack_channel_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+
     title: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -43,11 +48,6 @@ module.exports = (sequelize, DataTypes) => {
     tier: {
       type: DataTypes.INTEGER,
       allowNull: false,
-    },
-
-    slack_channel_id: {
-      type: DataTypes.STRING,
-      allowNull: true,
     },
   });
 


### PR DESCRIPTION
closes #179 

adds the `slack_channel_id` column and migration

passed local testing:
```
== 20171128084243-autobot_cohort_team_update: migrating =======
== 20171128084243-autobot_cohort_team_update: migrated (0.021s)
```
![cohort teams](https://user-images.githubusercontent.com/25523682/33310181-bf961ff2-d3ee-11e7-90aa-153761182444.png)
