### PR TITLE
Update cohort user #180

### DIFF
--- a/migrations/20171128085036-autobot_cohort_user_update.js
+++ b/migrations/20171128085036-autobot_cohort_user_update.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('cohort_users', 'slack_user_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('cohort_users', 'slack_user_id');
+  },
+};

--- a/migrations/20171128085036-autobot_cohort_user_update.js
+++ b/migrations/20171128085036-autobot_cohort_user_update.js
@@ -1,12 +1,8 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('cohort_users', 'slack_user_id', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-  },
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('cohort_users', 'slack_user_id', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  }),
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn('cohort_users', 'slack_user_id');
-  },
+  down: queryInterface => queryInterface.removeColumn('cohort_users', 'slack_user_id'),
 };

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
         key: 'id',
       },
     },
+
     cohort_tier_id: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
         key: 'id',
       },
     },
+
     cohort_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -25,6 +26,7 @@ module.exports = (sequelize, DataTypes) => {
         key: 'id',
       },
     },
+
     cohort_tier_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -47,8 +49,14 @@ module.exports = (sequelize, DataTypes) => {
       ],
       defaultValue: 'pending_approval',
     },
+
     tier: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+
+    slack_user_id: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   });

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -17,6 +17,11 @@ module.exports = (sequelize, DataTypes) => {
       },
     },
 
+    slack_user_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+
     cohort_id: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -52,11 +57,6 @@ module.exports = (sequelize, DataTypes) => {
 
     tier: {
       type: DataTypes.INTEGER,
-      allowNull: true,
-    },
-
-    slack_user_id: {
-      type: DataTypes.STRING,
       allowNull: true,
     },
   });


### PR DESCRIPTION
closes #180 

adds `slack_user_id` column and associated migration for cohort_user model

passed local testing
```
== 20171128085036-autobot_cohort_user_update: migrating =======
== 20171128085036-autobot_cohort_user_update: migrated (0.021s)
```
![cohort_users](https://user-images.githubusercontent.com/25523682/33310488-c7aebc52-d3ef-11e7-8d64-4d6d01348d19.png)
