### PR TITLE
Remove slack fields from `Cohort` model

### DIFF
--- a/migrations/20171202080400-create-autobot.js
+++ b/migrations/20171202080400-create-autobot.js
@@ -20,11 +20,13 @@ module.exports = {
 
     slack_team_id: {
       type: Sequelize.STRING,
+      unique: true,
       allowNull: false,
     },
 
     slack_team_token: {
       type: Sequelize.STRING,
+      unique: true,
       allowNull: false,
     },
 

--- a/migrations/20171202231839-remove_duplicate_slack_fields.js
+++ b/migrations/20171202231839-remove_duplicate_slack_fields.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: queryInterface => Promise.all([
+    queryInterface.removeColumn('cohorts', 'slack_team_token'),
+    queryInterface.removeColumn('cohorts', 'slack_bot_token'),
+    queryInterface.removeColumn('cohorts', 'slack_team_id'),
+    queryInterface.removeColumn('cohorts', 'autobot_id'),
+  ]),
+
+  down: (queryInterface, Sequelize) => Promise.all([
+    queryInterface.addColumn('cohorts', 'slack_team_token', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    }),
+    queryInterface.addColumn('cohorts', 'slack_bot_token', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    }),
+    queryInterface.addColumn('cohorts', 'slack_team_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    }),
+    queryInterface.addColumn('cohorts', 'autobot_id', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    }),
+  ]),
+};

--- a/models/autobot.js
+++ b/models/autobot.js
@@ -20,11 +20,13 @@ module.exports = (sequelize, DataTypes) => {
 
     slack_team_id: {
       type: DataTypes.STRING,
+      unique: true,
       allowNull: false,
     },
 
     slack_team_token: {
       type: DataTypes.STRING,
+      unique: true,
       allowNull: false,
     },
 

--- a/models/cohort.js
+++ b/models/cohort.js
@@ -48,26 +48,6 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DATE,
       allowNull: true,
     },
-
-    slack_team_token: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-
-    slack_team_id: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-
-    slack_autobot_token: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-
-    autobot_id: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
   });
 
   Cohort.associate = (models) => {


### PR DESCRIPTION
Closes #200.

Remove slack fields from `Cohort` model

- Created a migration to remove the slack columns from `cohorts`
- Removed the columns from the `Cohort` model
- Added a unique index for `slack_team_id` and `slack_team_token` in the `AutoBot` model & migration