### PR TITLE
Add status to cohort team user #201

### DIFF
--- a/migrations/20171203015645-add_status_to_cohort_team_user.js
+++ b/migrations/20171203015645-add_status_to_cohort_team_user.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('cohort_team_users', 'status', {
+    allowNull: false,
+    type: Sequelize.ENUM,
+    values: ['active', 'removed', 'reassigned'],
+    defaultValue: 'active',
+  }),
+
+  down: queryInterface => queryInterface.removeColumn('cohort_team_users', 'status'),
+};

--- a/models/cohort_team_user.js
+++ b/models/cohort_team_user.js
@@ -32,6 +32,13 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       values: ['project_manager', 'member'],
     },
+
+    status: {
+      allowNull: false,
+      type: DataTypes.ENUM,
+      values: ['active', 'removed', 'reassigned'],
+      defaultValue: 'active',
+    },
   });
 
   CohortTeamUser.associate = (models) => {

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -22,6 +22,12 @@ module.exports = `
     member
   }
 
+  enum _CohortTeamUserStatus {
+    active
+    removed
+    reassigned
+  }
+
   enum _CohortUserStatus {
     pending_approval
     rejected
@@ -159,6 +165,7 @@ module.exports = `
   type CohortTeamUser {
     id: ID!
     role: _CohortTeamUserRole
+    status: _CohortTeamUserStatus
     user: User!
     cohort: Cohort!
   }


### PR DESCRIPTION
Closes #201.

Add `status` to `CohortTeamUser`

- Create a migration that adds the `status` column to the `cohort_team_users` table
- Add `status` to the `CohortTeamUser` model
- Add an enum called `_CohortTeamUserStatus` to the GraphQL schema
- Add a `status` property to the type schema for `CohortTeamUser`