### PR TITLE
Add `autobotCreateCohortTeam` mutation that creates a `CohortTeam`

### DIFF
--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -47,11 +47,6 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
 
-    tier: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-
     standup_schedule: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -71,9 +66,9 @@ module.exports = (sequelize, DataTypes) => {
 
   CohortTeam.prototype.generateTitle = async function generateTitle() {
     const team_count = await CohortTeam.count({ where: { cohort_id: this.cohort_id } });
-    const cohort = await this.getCohort();
-    const tier_title = (await cohort.getTiers({ where: { level: this.tier } }))[0].title;
-    this.title = `${tier_title}-team-${team_count}`;
+    const cohort_tier = await this.getCohortTier();
+    const tier = await cohort_tier.getTier();
+    this.title = `${tier.title}-team-${team_count}`;
   };
 
   return CohortTeam;

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -54,11 +54,6 @@ module.exports = (sequelize, DataTypes) => {
       ],
       defaultValue: 'pending_approval',
     },
-
-    tier: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-    },
   });
 
   CohortUser.prototype.isAccepted = () => {

--- a/models/tier.js
+++ b/models/tier.js
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       type: DataTypes.INTEGER,
     },
+
     title: {
       allowNull: false,
       unique: true,

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -134,7 +134,7 @@ module.exports = {
     createCohortTeam: async (root, data, { models: { CohortTeam, Project }, jwt_object }) => {
       await requireAdmin(jwt_object);
       const cohort_team = CohortTeam.build(data);
-      cohort_team.generateTitle();
+      await cohort_team.generateTitle();
       const project = await Project.create({ title: `${cohort_team.title} Project` });
       cohort_team.project_id = project.id;
       return cohort_team.save();

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -40,12 +40,45 @@ module.exports = {
     updateAutobot: async (
       root,
       { slack_team_id, autobot_data },
-      { models: { Autobot },
-      is_autobot },
+      { models: { Autobot }, is_autobot },
     ) => {
       requireAutobot(is_autobot);
-      const autobot = Autobot.findOne({ where: { slack_team_id } });
+      const autobot = await Autobot.findOne({ where: { slack_team_id } });
       return autobot.update(autobot_data);
+    },
+
+    autobotCreateCohortTeam: async (
+      root,
+      { slack_team_id, title, slack_channel_id },
+      { models: { Autobot, CohortTeam, Project, Tier, CohortTier }, is_autobot },
+    ) => {
+      requireAutobot(is_autobot);
+      const autobot = await Autobot.findOne({ where: { slack_team_id } });
+      // Get CohortTier based on title
+      let tier_title = 'Bears';
+      if (title.indexOf('Bears') === -1) {
+        if (title.indexOf('Geckos') > 0) {
+          tier_title = 'Geckos';
+        } else if (title.indexOf('Toucans') > 0) {
+          tier_title = 'Toucans';
+        } else {
+          throw new Error('Cannot map team title to tier.');
+        }
+      }
+      const tier = await Tier.findOne({ where: { title: tier_title } });
+      const cohort_tier = await CohortTier.findOne({
+        where: { tier_id: tier.id, cohort_id: autobot.cohort_id },
+      });
+      // Create team & project
+      const cohort_team = CohortTeam.build({
+        title,
+        slack_channel_id,
+        cohort_id: autobot.cohort_id,
+        cohort_tier_id: cohort_tier.id,
+      });
+      const project = await Project.create({ title: `${cohort_team.title} Project` });
+      cohort_team.project_id = project.id;
+      return cohort_team.save();
     },
 
     createCountry: async (root, { name }, { models: { Country, Group }, jwt_object }) => {
@@ -101,8 +134,8 @@ module.exports = {
     createCohortTeam: async (root, data, { models: { CohortTeam, Project }, jwt_object }) => {
       await requireAdmin(jwt_object);
       const cohort_team = CohortTeam.build(data);
-      await cohort_team.generateTitle();
-      const project = await Project.create({ title: cohort_team.title });
+      cohort_team.generateTitle();
+      const project = await Project.create({ title: `${cohort_team.title} Project` });
       cohort_team.project_id = project.id;
       return cohort_team.save();
     },

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -143,6 +143,7 @@ module.exports = `
   type CohortTeam {
     id: ID!
     title: String!
+    slack_channel_id: String!
     cohort: Cohort!
     project: Project!
     cohort_tier: CohortTier!
@@ -262,6 +263,7 @@ module.exports = `
   type Mutation {
     createAutobot(autobot_data: AutobotInput!): Autobot!
     updateAutobot(slack_team_id: String!, autobot_data: AutobotInput!): Autobot!
+    autobotCreateCohortTeam(slack_team_id: String!, title: String!, slack_channel_id: String!): CohortTeam!
 
     createCountry(name: String!): Country!
     createCity(country_id: ID!, name: String!): City!
@@ -271,7 +273,7 @@ module.exports = `
     updateCohort(cohort_id: ID!, cohort_data: CohortInput!): Cohort!
     addTierToCohort(cohort_id: ID!, tier_id: ID!): CohortTier!
     updateCohortUser(cohort_user_id: ID!, cohort_user_data: CohortUserInput!): CohortUser!
-    createCohortTeam(cohort_id: ID!, tier: Int!): CohortTeam!
+    createCohortTeam(cohort_id: ID!, cohort_tier_id: Int!): CohortTeam!
     addUserToCohortTeam(cohort_team_id: ID!, user_id: ID!, role: _CohortTeamUserRole): CohortTeamUser!
 
     createUser(user_data: UserInput!, email: String!, password: String!): Token!


### PR DESCRIPTION
- Remove the `tier` property from the `CohortTeam` model
- Modify the `generateTitle` method in `CohortTeam` to use the `getCohortTier` association instead of the old `tier` property
- Remove the `tier` property from the `CohortUser` model
- Add the `await` keyword in the `updateAutobot` mutation resolver _(small fix)_
- Add the `autobotCreateCohortTeam` resolver that takes in a `slack_team_id`, a `title`, and a `slack_channel_id`. It uses the `slack_team_id` to grab the associated `Autobot` entry because we need the `cohort_id` to associate the team. Then, based on the `title` that was passed in, it determines what tier this team is and then grabs the associated `CohotTier`. Finally, it creates a `Project` and a `CohortTeam`
- Remove the `await` keyword from the `createCohortTeam` mutation resolver and fix the project title _(small fix)_
- Update `type-defs.js` to include the new mutation, add the `slack_channel_id` to the `CohortTeam` type, and update the `createCohortTeam` mutation schema to use `cohort_tier_id` instead of `tier`

Closes #212