### PR TITLE
Add unregisterCohortTeamCohortUser mutation

### DIFF
--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -80,6 +80,7 @@ module.exports = (sequelize, DataTypes) => {
       through: models.CohortTeamCohortUser,
       as: 'Teams',
     });
+    CohortUser.hasMany(models.CohortTeamCohortUser, { as: 'TeamAssociations' });
     CohortUser.hasMany(models.CohortUserStandup, { as: 'Standups' });
   };
 

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -273,6 +273,11 @@ module.exports = `
       email_base: String!
       role: _CohortTeamCohortUserRole!
     ): CohortTeamCohortUser!
+    unregisterCohortTeamCohortUser(
+      slack_team_id: String!,
+      slack_channel_id: String!,
+      slack_user_id: String!
+    ): CohortTeamCohortUser!
     autobotCreateCohortTeam(slack_team_id: String!, title: String!, slack_channel_id: String!): CohortTeam!
 
     createCountry(name: String!): Country!


### PR DESCRIPTION
- Update the schema TypeDefs to include `unregisterCohortTeamCohortUser` mutation which accepts `slack_team_id`, `slack_channel_id`, and `slack_user_id`
- Update the `registerCohortTeamCohortUser` mutation to check if a user exists, and also to check that the user is not already an active member of another team. Also, update all teams associated with that `CohortUser` to reassigned. If no prior teams exist and this is the users first registration then nothing happens. If a user has previously been removed from a team in this cohort that `CohortTeamCohortUser` status is changed from `removed` to `reassigned`. If a user is already active in another team this request fails
- Add the `unregisterCohortTeamCohortUser` mutation resolver in the resolvers file. This updates the status of the `CohortTeamCohortUser` to *removed* and also updates the status of the `CohortUser` to *tier_assigned*

Closes #207 