### PR TITLE
remove cohort_id from required field in Autobotinput

### DIFF
--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -234,7 +234,6 @@ module.exports = `
     slack_team_token: String
     bot_id: String
     bot_token: String
-    cohort_id: Int
   }
 
   input UserInput {


### PR DESCRIPTION
removes the required field `cohort_id: Int` as it is not known at the time of using the createAutobot mutation