### PR TITLE
Rename 'Autobot' to 'Wizard'

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
 const cors = require('cors');
 const mongoose = require('mongoose');
 const { getConfigPath } = require('./config/utilities');
-const { authenticate, authenticateAutobot } = require('./config/auth');
+const { authenticate, authenticateWizard } = require('./config/auth');
 
 const { AUTH_HEADER, MONGO_URL, ALLOW_GRAPHIQL } = require(getConfigPath('config'));
 const models = require('./models');
@@ -29,9 +29,9 @@ app.use(cors(corsOptions));
 
 const buildOptions = async (req) => {
   const jwt_object = await authenticate(req);
-  const is_autobot = authenticateAutobot(req);
+  const is_wizard = authenticateWizard(req);
   return {
-    context: { models, jwt_object, is_autobot },
+    context: { models, jwt_object, is_wizard },
     schema,
   };
 };

--- a/config/auth.js
+++ b/config/auth.js
@@ -2,32 +2,32 @@ const jwt = require('jsonwebtoken');
 const { User, CohortUser } = require('../models');
 const { getConfigPath } = require('./utilities');
 
-const { JWT_SECRET, AUTOBOT_CDN_API_SECRET } = require(getConfigPath('config'));
+const { JWT_SECRET, WIZARD_CDN_API_SECRET } = require(getConfigPath('config'));
 
-const authenticateAutobot = ({ headers: { authorization } }) => {
+const authenticateWizard = ({ headers: { authorization } }) => {
   if (!authorization) return false;
 
-  return authorization === AUTOBOT_CDN_API_SECRET;
+  return authorization === WIZARD_CDN_API_SECRET;
 };
 
-const requireAutobot = (autobot) => {
-  if (!autobot) {
-    throw new Error('Autobot privileges required.');
+const requireWizard = (wizard) => {
+  if (!wizard) {
+    throw new Error('Wizard privileges required.');
   }
 };
 
-const requireSlackAdmin = async (autobot, bot_secret, slack_user_id) => {
+const requireSlackAdmin = async (wizard, bot_secret, slack_user_id) => {
   if (bot_secret) {
-    if (autobot.cohort_id) {
-      throw new Error('This secret is no longer valid. Autobot has already been integrated.');
+    if (wizard.cohort_id) {
+      throw new Error('This secret is no longer valid. Wizard has already been integrated.');
     }
 
-    if (autobot.bot_secret !== bot_secret) {
+    if (wizard.bot_secret !== bot_secret) {
       throw new Error('Invalid secret. Permission denied.');
     }
   } else {
     const cohort_user = await CohortUser({
-      where: { cohort_id: autobot.cohort_id, slack_user_id },
+      where: { cohort_id: wizard.cohort_id, slack_user_id },
     });
     const user = await cohort_user.getUser();
     if (user.role !== 'admin') {
@@ -79,8 +79,8 @@ const requireAdmin = async (jwt_object) => {
 };
 
 module.exports = {
-  authenticateAutobot,
-  requireAutobot,
+  authenticateWizard,
+  requireWizard,
   requireSlackAdmin,
   authenticate,
   getLoggedInUser,

--- a/config/config.js
+++ b/config/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   JWT_SECRET: process.env.JWT_SECRET,
   MONGO_URL: process.env.MONGO_URL,
-  AUTOBOT_CDN_API_SECRET: process.env.AUTOBOT_CDN_API_SECRET,
+  WIZARD_CDN_API_SECRET: process.env.WIZARD_CDN_API_SECRET,
   ALLOW_GRAPHIQL: process.env.ALLOW_GRAPHIQL,
 };

--- a/migrations/20171213053441-drop_autobots.js
+++ b/migrations/20171213053441-drop_autobots.js
@@ -1,0 +1,60 @@
+module.exports = {
+  up: queryInterface => queryInterface.dropTable('autobots'),
+
+  down: (queryInterface, Sequelize) => queryInterface.createTable('autobots', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+
+    cohort_id: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      unique: true,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohorts',
+        key: 'id',
+      },
+    },
+
+    slack_team_id: {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    },
+
+    bot_secret: {
+      allowNull: false,
+      type: Sequelize.STRING,
+    },
+
+    slack_team_token: {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    },
+
+    bot_id: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+
+    bot_token: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+};

--- a/migrations/20171213054901-create_wizards.js
+++ b/migrations/20171213054901-create_wizards.js
@@ -1,0 +1,60 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('wizards', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+
+    cohort_id: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      unique: true,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohorts',
+        key: 'id',
+      },
+    },
+
+    slack_team_id: {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    },
+
+    bot_secret: {
+      allowNull: false,
+      type: Sequelize.STRING,
+    },
+
+    slack_team_token: {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    },
+
+    bot_id: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+
+    bot_token: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+
+  down: queryInterface => queryInterface.dropTable('wizards'),
+};

--- a/models/cohort.js
+++ b/models/cohort.js
@@ -56,7 +56,7 @@ module.exports = (sequelize, DataTypes) => {
     Cohort.belongsToMany(models.Project, { through: models.CohortTeam });
     Cohort.hasMany(models.CohortUser, { as: 'Members' });
     Cohort.hasMany(models.CohortTeam, { as: 'Teams' });
-    Cohort.hasOne(models.Autobot);
+    Cohort.hasOne(models.Wizard);
     Cohort.belongsTo(models.Group);
   };
 

--- a/models/wizard.js
+++ b/models/wizard.js
@@ -1,7 +1,7 @@
 const { randomBytes } = require('crypto');
 
 module.exports = (sequelize, DataTypes) => {
-  const Autobot = sequelize.define('Autobot', {
+  const Wizard = sequelize.define('Wizard', {
     id: {
       allowNull: false,
       autoIncrement: true,
@@ -48,7 +48,7 @@ module.exports = (sequelize, DataTypes) => {
     },
   });
 
-  Autobot.prototype.generateSecret = () => new Promise((resolve, reject) => {
+  Wizard.prototype.generateSecret = () => new Promise((resolve, reject) => {
     randomBytes(48, (err, buffer) => {
       if (err) reject(err);
       this.bot_secret = buffer.toString('hex');
@@ -56,9 +56,9 @@ module.exports = (sequelize, DataTypes) => {
     });
   });
 
-  Autobot.associate = (models) => {
-    Autobot.belongsTo(models.Cohort);
+  Wizard.associate = (models) => {
+    Wizard.belongsTo(models.Cohort);
   };
 
-  return Autobot;
+  return Wizard;
 };

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -67,7 +67,7 @@ module.exports = `
     tiers: [Tier!]!
   }
 
-  type Autobot {
+  type Wizard {
     slack_team_id: String!
     slack_team_token: String!
     bot_id: String!
@@ -220,7 +220,7 @@ module.exports = `
   }
 
   type Query {
-    autobot(slack_team_id: String!): Autobot
+    wizard(slack_team_id: String!): Wizard
     cohortTeam(slack_team_id: String!, slack_channel_id: String!): CohortTeam!
     cohortTeams(slack_team_id: String!): [CohortTeam!]!
 
@@ -233,7 +233,7 @@ module.exports = `
     projects(limit: Int = 10, offset: Int = 0): [Project!]!
   }
 
-  input AutobotInput {
+  input WizardInput {
     slack_team_id: String
     slack_team_token: String
     bot_id: String
@@ -268,12 +268,12 @@ module.exports = `
   }
 
   type Mutation {
-    createAutobot(autobot_data: AutobotInput!): Autobot!
-    integrateAutobotWithCohort(
+    createWizard(wizard_data: WizardInput!): Wizard!
+    integrateWizardWithCohort(
       slack_team_id: String!,
       cohort_id: Int!,
       bot_secret: String!
-    ): Autobot!
+    ): Wizard!
     registerCohortTeamCohortUser(
       slack_team_id: String!,
       slack_channel_id: String!,
@@ -287,7 +287,7 @@ module.exports = `
       slack_user_id: String!
       admin_slack_user_id: String!
     ): CohortTeamCohortUser!
-    autobotCreateCohortTeam(
+    wizardCreateCohortTeam(
       slack_team_id: String!,
       title: String!,
       slack_channel_id: String!


### PR DESCRIPTION
- Create migration to drop `autobots` table and constraints.
-  Create migration to create `wizards` table.
- Rename the `Autobot` model to `Wizard`.
- Fix references to & from the model.
- Rename all instances of `Autobot` to `Wizard` in the resolvers and type defs.
- Rename the auth functions.
- Use the new names in `app.js`.

Closes #221 