### PR TITLE
Fixed automatic cohort integrations

### DIFF
--- a/migrations/20171214001135-drop_project_id_from_cohort_teams.js
+++ b/migrations/20171214001135-drop_project_id_from_cohort_teams.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up: queryInterface => queryInterface.removeColumn('cohort_teams', 'project_id'),
+
+  down: (queryInterface, Sequelize) => queryInterface.addColumn('cohort_teams', 'project_id', {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    onDelete: 'CASCADE',
+    references: {
+      model: 'projects',
+      key: 'id',
+    },
+  }),
+};

--- a/migrations/20171214001526-add_project_id_to_cohort_teams.js
+++ b/migrations/20171214001526-add_project_id_to_cohort_teams.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('cohort_teams', 'project_id', {
+    type: Sequelize.INTEGER,
+    allowNull: true,
+    onDelete: 'SET NULL',
+    references: {
+      model: 'projects',
+      key: 'id',
+    },
+  }),
+
+  down: queryInterface => queryInterface.removeColumn('cohort_teams', 'project_id'),
+};

--- a/models/cohort.js
+++ b/models/cohort.js
@@ -56,6 +56,7 @@ module.exports = (sequelize, DataTypes) => {
     Cohort.belongsToMany(models.Project, { through: models.CohortTeam });
     Cohort.hasMany(models.CohortUser, { as: 'Members' });
     Cohort.hasMany(models.CohortTeam, { as: 'Teams' });
+    Cohort.hasMany(models.CohortTier);
     Cohort.hasOne(models.Wizard);
     Cohort.belongsTo(models.Group);
   };

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -29,8 +29,8 @@ module.exports = (sequelize, DataTypes) => {
 
     project_id: {
       type: DataTypes.INTEGER,
-      allowNull: false,
-      onDelete: 'CASCADE',
+      allowNull: true,
+      onDelete: 'SET NULL',
       references: {
         model: 'projects',
         key: 'id',

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -76,14 +76,7 @@ module.exports = {
       root,
       { slack_team_id, slack_channel_id, slack_user_id, email_base, role },
       {
-        models: {
-          Wizard,
-          User,
-          CohortTeam,
-          CohortUser,
-          CohortTeamCohortUser,
-          ProjectUser,
-        },
+        models: { Wizard, User, CohortTeam, CohortUser, CohortTeamCohortUser, ProjectUser },
         is_wizard,
       },
     ) => {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -75,7 +75,17 @@ module.exports = {
     registerCohortTeamCohortUser: async (
       root,
       { slack_team_id, slack_channel_id, slack_user_id, email_base, role },
-      { models: { Wizard, User, CohortTeam, CohortUser, CohortTeamCohortUser, ProjectUser }, is_wizard },
+      {
+        models: {
+          Wizard,
+          User,
+          CohortTeam,
+          CohortUser,
+          CohortTeamCohortUser,
+          ProjectUser,
+        },
+        is_wizard,
+      },
     ) => {
       requireWizard(is_wizard);
       const wizard = await Wizard.findOne({ where: { slack_team_id } });
@@ -146,7 +156,7 @@ module.exports = {
     wizardCreateCohortTeam: async (
       root,
       { slack_team_id, title, slack_channel_id, slack_user_id },
-      { models: { Wizard, Cohort, CohortTeam, Project, Tier, CohortTier }, is_wizard },
+      { models: { Wizard, Cohort, CohortTeam, Project, CohortTier }, is_wizard },
     ) => {
       requireWizard(is_wizard);
       const wizard = await Wizard.findOne({ where: { slack_team_id } });


### PR DESCRIPTION
- Modified `project_id` column in `cohort_teams` to allow null and the `onDelete` constraint on that column now sets it to null.
- Added the `CohortTier` association to the `Cohort` model.
-  Modified the `project_id` column in the `CohortTeam` model to match the migrations.

## In Resolvers:
### registerCohortTeamCohortUser mutation:

- Allowed matching of slack user to chingu user using either the base of the email or the `slack_user_id`.
- Connecting a user to the team project once the team association with that user has been successfully created.

### wizardCreateCohortTeam mutation:

- Modified the tier matching to be more dynamic by searching through the tiers associated with the particular cohort.
- Now creating `cohort_team` before `project`  so as to make sure that if the team creation fails the project is never created.