### PR TITLE
create createMilestone mutation

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -242,6 +242,11 @@ module.exports = {
       return Cohort.create({ title, group_id: group.id });
     },
 
+    createMilestone: async (root, { milestone_data }, { models: { Milestone }, jwt_object }) => {
+      await requireAdmin(jwt_object);
+      return Milestone.create(milestone_data);
+    },
+
     createCohortTierAct: async (
       root,
       { act_data: { cohort_id, tier_id, title, order_index, repeatable } },

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -324,7 +324,7 @@ module.exports = `
       role: _CohortTeamCohortUserRole!
     ): CohortTeamCohortUser!
 
-    createMilestone(milestone_data: MilestoneInput!): Milestone!\
+    createMilestone(milestone_data: MilestoneInput!): Milestone!
     createCohortTierAct(act_data: CohortTierActInput!): CohortTierAct!
 
     createUser(user_data: UserInput!, email: String!, password: String!): Token!

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -88,7 +88,7 @@ module.exports = `
   type Milestone {
     id: ID!
     title: String!
-    decription: String
+    description: String
     resource_url: String
     acts: [CohortTierAct!]!
   }
@@ -275,6 +275,12 @@ module.exports = `
     repeatable: Boolean
   }
 
+  input MilestoneInput {
+    title: String
+    description: String
+    resource_url: String
+  }
+
   type Mutation {
     createWizard(wizard_data: WizardInput!): Wizard!
     integrateWizardWithCohort(
@@ -318,6 +324,7 @@ module.exports = `
       role: _CohortTeamCohortUserRole!
     ): CohortTeamCohortUser!
 
+    createMilestone(milestone_data: MilestoneInput!): Milestone!\
     createCohortTierAct(act_data: CohortTierActInput!): CohortTierAct!
 
     createUser(user_data: UserInput!, email: String!, password: String!): Token!


### PR DESCRIPTION
closes #235 

# create createMilestone mutation

### `schema/type-defs`

- added MilestoneInput and createMilestone mutation definitions
- fixed typo in Milestone type definition

### `schema/resolvers`

- added the createMilestone mutation
- accepts milestone_data input and returns the new Milestone entry

### Debugged and fully functional
![screen shot 2017-12-16 at 1 58 39 am](https://user-images.githubusercontent.com/25523682/34068142-da0293c4-e204-11e7-87ec-b74fa23afb44.png)
![screen shot 2017-12-16 at 1 59 07 am](https://user-images.githubusercontent.com/25523682/34068143-dcb04846-e204-11e7-9fbe-d09e3196270a.png)
