### PR TITLE
Create cohort tier act milestone mutation #204

### DIFF
--- a/models/cohort_tier_act_milestone.js
+++ b/models/cohort_tier_act_milestone.js
@@ -35,7 +35,7 @@ module.exports = (sequelize, DataTypes) => {
   });
 
   CohortTierActMilestone.associate = (models) => {
-    CohortTierActMilestone.belongsTo(models.CohortTierAct, { as: 'Act' });
+    CohortTierActMilestone.belongsTo(models.CohortTierAct);
     CohortTierActMilestone.belongsTo(models.Milestone);
     CohortTierActMilestone.belongsToMany(models.CohortTeamTierAct, {
       through: models.CohortTeamTierActMilestone,

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -254,6 +254,15 @@ module.exports = {
       );
     },
 
+    createCohortTierActMilestone: async (
+      root,
+      { act_milestone_data },
+      { models: { CohortTierActMilestone }, jwt_object },
+    ) => {
+      await requireAdmin(jwt_object);
+      return CohortTierActMilestone.create(act_milestone_data);
+    },
+
     updateCohort: async (root, { cohort_id, cohort_data }, { models: { Cohort }, jwt_object }) => {
       await requireAdmin(jwt_object);
       const cohort = await Cohort.findById(cohort_id);

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -412,7 +412,7 @@ module.exports = {
   },
 
   CohortTierActMilestone: {
-    act: root => root.getAct(),
+    act: root => root.getCohortTierAct(),
     milestone: root => root.getMilestone(),
     team_acts: root => root.getTeamActs(),
   },

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -275,6 +275,12 @@ module.exports = `
     repeatable: Boolean
   }
 
+  input CohortTierActMilestoneInput {
+    cohort_tier_act_id: Int
+    milestone_id: Int
+    order_index: Int  
+  }
+
   type Mutation {
     createWizard(wizard_data: WizardInput!): Wizard!
     integrateWizardWithCohort(
@@ -319,7 +325,10 @@ module.exports = `
     ): CohortTeamCohortUser!
 
     createCohortTierAct(act_data: CohortTierActInput!): CohortTierAct!
-
+    createCohortTierActMilestone(
+      act_milestone_data: CohortTierActMilestoneInput!
+    ): CohortTierActMilestone!
+    
     createUser(user_data: UserInput!, email: String!, password: String!): Token!
     signInUser(email: String!, password: String!): Token!
     updateUser(user_data: UserInput!): User!


### PR DESCRIPTION
closes #204 

# Create CohortTierActMilestone Mutation

### `models/cohort_tier_act_milestones`

- fixed the alias issue that was causing a bug in returning the associated  cohortTierAct 

### `schema/type-defs`

- added the CohortTierActMilestone input and mutation definitions

### `schema/resolvers`

- created the createCohortTierActMilestone mutation
- accepts the act_milestone_data input object and returns the new CohortTierActMileston database entry
- fixed the corresponding CohortTierAct alias issue at the CohortTierActMilestone query resolver\

### Debugged and fully functional
![screen shot 2017-12-16 at 2 14 42 am](https://user-images.githubusercontent.com/25523682/34068353-6ce1846e-e207-11e7-977e-f816b6f42e97.png)
![screen shot 2017-12-16 at 2 15 12 am](https://user-images.githubusercontent.com/25523682/34068355-6fe6c908-e207-11e7-8d28-fd01f307e6f2.png)

#### the `description` field mispelling was corrected in the previous PR