### PR TITLE
Add unique constraint to cohort_tier_act_milestones

### DIFF
--- a/migrations/20171218023827-add_unique_constraint_to_cohort_tier_act_milestones.js
+++ b/migrations/20171218023827-add_unique_constraint_to_cohort_tier_act_milestones.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: queryInterface => queryInterface.addConstraint(
+      'cohort_tier_act_milestones',
+      ['milestone_id', 'cohort_tier_act_id'],
+    {
+      type: 'unique',
+      name: 'cohort_tier_act_milestones_milestone-cohort_tier_act_unique_index',
+    },
+  ),
+
+  down: queryInterface => queryInterface.removeConstraint(
+    'cohort_tier_act_milestones',
+    'cohort_tier_act_milestones_milestone-cohort_tier_act_unique_index',
+  ),
+};


### PR DESCRIPTION
- Create a migration that adds a unique constraint to `cohort_tier_act_milestones` table for the fields `milestone_id` and `cohort_tier_act_id`. Essentially, no act can include a single milestone more than once.

Closes #246 #251 