### PR TITLE
Add an auth method to check for project manager

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -3,6 +3,7 @@ const {
   checkUserPermissions,
   getLoggedInUser,
   requireWizard,
+  requireProjectManager,
   requireSlackAdmin,
   requireAdmin,
 } = require('../config/auth');
@@ -54,7 +55,7 @@ module.exports = {
 
     getNextMilestone: async (
       root,
-      { slack_team_id, slack_channel_id },
+      { slack_team_id, slack_channel_id, slack_user_id },
       { models: { CohortTeam, Wizard }, is_wizard },
     ) => {
       requireWizard(is_wizard);
@@ -63,6 +64,8 @@ module.exports = {
       const team = await CohortTeam.findOne({
         where: { cohort_id: wizard.cohort_id, slack_channel_id },
       });
+
+      await requireProjectManager(team, slack_user_id);
 
       return team.getNextMilestones();
     },
@@ -196,7 +199,7 @@ module.exports = {
 
     submitMilestone: async (
       root,
-      { slack_team_id, slack_channel_id, cohort_tier_act_milestone_id },
+      { slack_team_id, slack_channel_id, slack_user_id, cohort_tier_act_milestone_id },
       { models: { Wizard, CohortTeam, CohortTeamTierAct, CohortTeamTierActMilestone }, is_wizard },
     ) => {
       requireWizard(is_wizard);
@@ -204,6 +207,8 @@ module.exports = {
       const team = await CohortTeam.findOne({
         where: { cohort_id: wizard.cohort_id, slack_channel_id },
       });
+
+      await requireProjectManager(team, slack_user_id);
 
       const next_milestones = await team.getNextMilestones();
       const new_milestone = next_milestones.find(

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -224,7 +224,11 @@ module.exports = `
     cohortTeam(slack_team_id: String!, slack_channel_id: String!): CohortTeam!
     cohortTeams(slack_team_id: String!): [CohortTeam!]!
 
-    getNextMilestone(slack_team_id: String!, slack_channel_id: String!): [CohortTierActMilestone!]!
+    getNextMilestone(
+      slack_team_id: String!,
+      slack_channel_id: String!,
+      slack_user_id: String!
+    ): [CohortTierActMilestone!]!
 
     user(username: String, user_id: ID): User
     group(group_id: ID!): Group
@@ -318,6 +322,7 @@ module.exports = `
     submitMilestone(
       slack_team_id: String!,
       slack_channel_id: String!,
+      slack_user_id: String!,
       cohort_tier_act_milestone_id: Int!
     ): CohortTeamTierActMilestone!
 


### PR DESCRIPTION
- Add a method that checks that a user is the project manager of a team.
- Make use of the new auth method in the `getNextMilestone` query and the `submitMilestone` mutation.
- Update the typedefs to accept a `slack_user_id` for those mutations.

Closes #249 