### PR TITLE
Refactor the requireWizard auth method

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const { User, CohortUser } = require('../models');
+const { Wizard, User, CohortUser } = require('../models');
 const { getConfigPath } = require('./utilities');
 
 const { JWT_SECRET, WIZARD_CDN_API_SECRET } = require(getConfigPath('config'));
@@ -10,10 +10,21 @@ const authenticateWizard = ({ headers: { authorization } }) => {
   return authorization === WIZARD_CDN_API_SECRET;
 };
 
-const requireWizard = (wizard) => {
-  if (!wizard) {
+const requireWizard = async (is_wizard, slack_team_id) => {
+  if (!is_wizard) {
     throw new Error('Wizard privileges required.');
   }
+
+  if (slack_team_id) {
+    const wizard = Wizard.findOne({ where: { slack_team_id } });
+    if (!wizard) {
+      throw new Error('This wizard does not exist');
+    }
+
+    return wizard;
+  }
+
+  return true;
 };
 
 const requireSlackAdmin = async (wizard, bot_secret, slack_user_id) => {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -21,28 +21,26 @@ module.exports = {
 
     group: async (root, { group_id }, { models: { Group } }) => Group.findById(group_id),
 
-    wizard: async (root, { slack_team_id }, { models: { Wizard }, is_wizard }) => {
-      requireWizard(is_wizard);
-      return Wizard.findOne({ where: { slack_team_id } });
-    },
+    wizard: async (root, { slack_team_id }, { is_wizard }) => requireWizard(
+      is_wizard,
+      slack_team_id,
+    ),
 
     cohortTeam: async (
       root,
       { slack_team_id, slack_channel_id },
-      { models: { Wizard, CohortTeam }, is_wizard },
+      { models: { CohortTeam }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       return CohortTeam.findOne({ where: { cohort_id: wizard.cohort_id, slack_channel_id } });
     },
 
     cohortTeams: async (
       root,
       { slack_team_id },
-      { models: { Wizard, CohortTeam }, is_wizard },
+      { models: { CohortTeam }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       return CohortTeam.findAll({ where: { cohort_id: wizard.cohort_id } });
     },
 
@@ -55,10 +53,9 @@ module.exports = {
     getNextMilestone: async (
       root,
       { slack_team_id, slack_channel_id },
-      { models: { CohortTeam, Wizard }, is_wizard },
+      { models: { CohortTeam }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
 
       const team = await CohortTeam.findOne({
         where: { cohort_id: wizard.cohort_id, slack_channel_id },
@@ -79,10 +76,9 @@ module.exports = {
     integrateWizardWithCohort: async (
       root,
       { slack_team_id, cohort_id, bot_secret },
-      { models: { Wizard }, is_wizard },
+      { is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       requireSlackAdmin(wizard, bot_secret);
       return wizard.update({ cohort_id });
     },
@@ -91,12 +87,11 @@ module.exports = {
       root,
       { slack_team_id, slack_channel_id, slack_user_id, email_base, role },
       {
-        models: { Wizard, User, CohortTeam, CohortUser, CohortTeamCohortUser, ProjectUser },
+        models: { User, CohortTeam, CohortUser, CohortTeamCohortUser, ProjectUser },
         is_wizard,
       },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       const cohort_team = await CohortTeam.findOne({
         where: { slack_channel_id, cohort_id: wizard.cohort_id },
       });
@@ -143,10 +138,9 @@ module.exports = {
     unregisterCohortTeamCohortUser: async (
       root,
       { slack_team_id, slack_channel_id, slack_user_id, admin_slack_user_id },
-      { models: { Wizard, CohortTeam, CohortUser, CohortTeamCohortUser }, is_wizard },
+      { models: { CohortTeam, CohortUser, CohortTeamCohortUser }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       await requireSlackAdmin(wizard.cohort_id, null, admin_slack_user_id);
       const cohort_team = await CohortTeam.findOne({
         where: { slack_channel_id, cohort_id: wizard.cohort_id },
@@ -164,10 +158,9 @@ module.exports = {
     wizardCreateCohortTeam: async (
       root,
       { slack_team_id, title, slack_channel_id, slack_user_id },
-      { models: { Wizard, Cohort, CohortTeam, Project, CohortTier }, is_wizard },
+      { models: { Cohort, CohortTeam, Project, CohortTier }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       if (!wizard.cohort_id) {
         throw new Error('This wizard has not been associated with a cohort.');
       }
@@ -197,10 +190,9 @@ module.exports = {
     submitMilestone: async (
       root,
       { slack_team_id, slack_channel_id, cohort_tier_act_milestone_id },
-      { models: { Wizard, CohortTeam, CohortTeamTierAct, CohortTeamTierActMilestone }, is_wizard },
+      { models: { CohortTeam, CohortTeamTierAct, CohortTeamTierActMilestone }, is_wizard },
     ) => {
-      requireWizard(is_wizard);
-      const wizard = await Wizard.findOne({ where: { slack_team_id } });
+      const wizard = await requireWizard(is_wizard, slack_team_id);
       const team = await CohortTeam.findOne({
         where: { cohort_id: wizard.cohort_id, slack_channel_id },
       });


### PR DESCRIPTION
- The `requireWizard` method now accepts a `slack_team_id` which it uses to return the appropriate wizard.
- Refactored all the resolvers that make use of this method.

Closes #250 