### PR TITLE
Get cohort tier acts query

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -78,7 +78,9 @@ module.exports = {
       });
 
       const cohort_tier = await team.getCohortTier();
-      return cohort_tier.getActs();
+      return cohort_tier.getActs({
+        order: [['order_index', 'ASC']],
+      });
     },
   },
 
@@ -501,7 +503,9 @@ module.exports = {
 
   CohortTierAct: {
     cohort_tier: root => root.getCohortTier(),
-    act_milestones: root => root.getActMilestones(),
+    act_milestones: root => root.getActMilestones({
+      order: [['order_index', 'ASC']],
+    }),
     teams: root => root.getTeams(),
     team_acts: root => root.getTeamActs(),
   },

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -66,6 +66,20 @@ module.exports = {
 
       return team.getNextMilestones();
     },
+
+    getTierActs: async (
+      root,
+      { slack_team_id, slack_channel_id },
+      { models: { CohortTeam }, is_wizard },
+    ) => {
+      const wizard = await requireWizard(is_wizard, slack_team_id);
+      const team = await CohortTeam.findOne({
+        where: { cohort_id: wizard.cohort_id, slack_channel_id },
+      });
+
+      const cohort_tier = await team.getCohortTier();
+      return cohort_tier.getActs();
+    },
   },
 
   Mutation: {

--- a/schema/type-defs.js
+++ b/schema/type-defs.js
@@ -131,6 +131,7 @@ module.exports = `
     status: _CohortUserStatus!
     tier: Tier
     team: CohortTeam
+    slack_user_id: String 
     standups: [CohortUserStandup!]!
   }
 
@@ -229,6 +230,11 @@ module.exports = `
       slack_channel_id: String!,
       slack_user_id: String!
     ): [CohortTierActMilestone!]!
+
+    getTierActs(
+      slack_team_id: String!,
+      slack_channel_id: String!
+    ): [CohortTierAct!]!
 
     user(username: String, user_id: ID): User
     group(group_id: ID!): Group


### PR DESCRIPTION
## getCohortTierActs Query

### `typedefs`:

- added 'slack_user_id' (nullable) field to the CohortUser type
- added getTierActs query that accepts a slack team and channel ID and returns an array of CohortTierActs

### `resolvers`:

- added getTierActs query and logic
- sort CohortTierActs and CohortTierActMilestones by ascending `order_index` order