### PR TITLE
Fix: Add specific order to the retrieval or completed act milestones.

### DIFF
--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -74,7 +74,7 @@ module.exports = (sequelize, DataTypes) => {
   CohortTeam.prototype.getNextMilestones = async function getNextMilestone() {
     const team_acts = await sequelize.models.CohortTeamTierAct.findAll({
       include: ['CohortTierAct'],
-      order: [['CohortTierAct', 'order_index', 'ASC'], ['created_at', 'ASC']],
+      order: [['CohortTierAct', 'order_index', 'ASC'], ['repetition', 'ASC'], ['created_at', 'ASC']],
       where: { cohort_team_id: this.id },
     });
 
@@ -98,7 +98,9 @@ module.exports = (sequelize, DataTypes) => {
       order: [['order_index', 'DESC']],
     });
 
-    const completed_milestones = await last_team_act.getCompletedActMilestones();
+    const completed_milestones = await last_team_act.getCompletedActMilestones({
+      order: [['order_index', 'ASC'], ['created_at', 'ASC']],
+    });
     const last_completed_milestone = completed_milestones[completed_milestones.length - 1];
 
     // If the team hasn't completed an act, return the next milestone in the act.


### PR DESCRIPTION
**URGENT**:

There was an issue regarding the order of retrieval of completed act milestones. They were coming back in random order so I wasn't able to debug Act III.

The reason this didn't come up before is because the order is random when not specified. Odd really?