### PR TITLE
Create a Procfile for Heroku Deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: npm start
+worker: npm start


### PR DESCRIPTION
- Add a `Procfile` for specifying how Heroku should deploy the `web` dynos and the `worker` dynos