### PR TITLE
Define the Metadata Associations

### DIFF
--- a/models/cohort_channel.js
+++ b/models/cohort_channel.js
@@ -47,6 +47,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
   };
 

--- a/models/cohort_channel.js
+++ b/models/cohort_channel.js
@@ -38,9 +38,16 @@ module.exports = (sequelize, DataTypes) => {
     return this.title.toLowerCase().replace(' ', '-');
   };
 
-  CohortChannel.associate = ({ Cohort, CohortTeam }) => {
-    CohortChannel.belongsTo(Cohort);
-    CohortChannel.hasOne(CohortTeam);
+  CohortChannel.associate = (models) => {
+    CohortChannel.belongsTo(models.Cohort);
+    CohortChannel.hasOne(models.CohortTeam);
+    CohortChannel.hasMany(models.Metadata, {
+      scope: {
+        entity_type: 'CohortChannel',
+      },
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
   };
 
   return CohortChannel;

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -68,6 +68,13 @@ module.exports = (sequelize, DataTypes) => {
     CohortTeam.belongsTo(models.CohortTier);
     CohortTeam.belongsTo(models.CohortChannel);
     CohortTeam.belongsTo(models.Project);
+    CohortTeam.hasMany(models.Metadata, {
+      scope: {
+        entity_type: 'CohortTeam',
+      },
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
   };
 
   CohortTeam.prototype.generateTitle = async function generateTitle() {

--- a/models/cohort_team.js
+++ b/models/cohort_team.js
@@ -74,6 +74,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
   };
 

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -82,6 +82,13 @@ module.exports = (sequelize, DataTypes) => {
     });
     CohortUser.hasMany(models.CohortTeamCohortUser, { as: 'TeamAssociations' });
     CohortUser.hasMany(models.CohortUserStandup, { as: 'Standups' });
+    CohortUser.hasMany(models.Metadata, {
+      scope: {
+        entity_type: 'CohortUser',
+      },
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
   };
 
   return CohortUser;

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -88,6 +88,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
   };
 

--- a/models/metadata.js
+++ b/models/metadata.js
@@ -48,5 +48,25 @@ module.exports = (sequelize, DataTypes) => {
     },
   });
 
+  Metadata.associate = (models) => {
+    Metadata.belongsTo(models.MetadataSchema);
+    Metadata.belongsTo(models.CohortUser, {
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
+    Metadata.belongsTo(models.CohortChannel, {
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
+    // Metadata.belongsTo(models.CohortChannelUser, {
+    //   foreignKey: 'entity_id',
+    //   targetKey: 'id',
+    // });
+    Metadata.belongsTo(models.CohortTeam, {
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+    });
+  };
+
   return Metadata;
 };

--- a/models/metadata.js
+++ b/models/metadata.js
@@ -53,18 +53,22 @@ module.exports = (sequelize, DataTypes) => {
     Metadata.belongsTo(models.CohortUser, {
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
     Metadata.belongsTo(models.CohortChannel, {
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
     // Metadata.belongsTo(models.CohortChannelUser, {
     //   foreignKey: 'entity_id',
     //   targetKey: 'id',
+    //   constraints: false,
     // });
     Metadata.belongsTo(models.CohortTeam, {
       foreignKey: 'entity_id',
       targetKey: 'id',
+      constraints: false,
     });
   };
 

--- a/models/metadata_schema.js
+++ b/models/metadata_schema.js
@@ -1,5 +1,5 @@
 module.exports = (sequelize, DataTypes) => {
-  const MetadataSchema = DataTypes.define('MetadataSchema', {
+  const MetadataSchema = sequelize.define('MetadataSchema', {
     id: {
       allowNull: false,
       autoIncrement: true,
@@ -38,6 +38,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.JSONB,
     },
   });
+
+  MetadataSchema.associate = (models) => {
+    MetadataSchema.hasMany(models.Metadata);
+  };
 
   return MetadataSchema;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,6 +1797,11 @@
         "uuid": "3.1.0"
       }
     },
+    "graphql-type-json": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.1.4.tgz",
+      "integrity": "sha1-ifE/XTLOCMmnbHn9+cGWg4TYGk4="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^4.16.2",
     "graphql": "^0.11.7",
     "graphql-tools": "^2.7.2",
+    "graphql-type-json": "^0.1.4",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
     "pg": "^7.4.0",

--- a/schema/definition/enums/index.js
+++ b/schema/definition/enums/index.js
@@ -3,6 +3,7 @@ const CohortTeamCohortUserRoleEnum = require('./cohort_team_cohort_user_role_enu
 const CohortTeamCohortUserStatusEnum = require('./cohort_team_cohort_user_status_enum');
 const CohortUserStatusEnum = require('./cohort_user_status_enum');
 const UserStatusEnum = require('./user_status_enum');
+const MetadataSourceEnum = require('./metadata_source_enum');
 
 module.exports = [
   CohortStatusEnum,
@@ -10,4 +11,5 @@ module.exports = [
   CohortTeamCohortUserStatusEnum,
   CohortUserStatusEnum,
   UserStatusEnum,
+  MetadataSourceEnum,
 ];

--- a/schema/definition/enums/metadata_source_enum.js
+++ b/schema/definition/enums/metadata_source_enum.js
@@ -1,0 +1,10 @@
+let MetadataSourceEnum;
+
+module.exports = () => [MetadataSourceEnum];
+
+MetadataSourceEnum = `
+  enum _MetadataSource {
+    slack
+    github
+  }
+`;

--- a/schema/definition/scalars/index.js
+++ b/schema/definition/scalars/index.js
@@ -1,5 +1,7 @@
 const DateScalar = require('./date_scalar');
+const JSONScalar = require('./json_scalar');
 
 module.exports = [
   DateScalar,
+  JSONScalar,
 ];

--- a/schema/definition/scalars/json_scalar.js
+++ b/schema/definition/scalars/json_scalar.js
@@ -1,0 +1,7 @@
+let JSONScalar;
+
+module.exports = () => [JSONScalar];
+
+JSONScalar = `
+  scalar JSON
+`;

--- a/schema/definition/types/index.js
+++ b/schema/definition/types/index.js
@@ -19,6 +19,7 @@ const TokenType = require('./token_type');
 const UserType = require('./user_type');
 const WizardType = require('./wizard_type');
 const SkillType = require('./skill_type');
+const MetadataType = require('./metadata_type');
 
 module.exports = [
   CityType,
@@ -42,4 +43,5 @@ module.exports = [
   UserType,
   WizardType,
   SkillType,
+  MetadataType,
 ];

--- a/schema/definition/types/metadata_type.js
+++ b/schema/definition/types/metadata_type.js
@@ -1,7 +1,8 @@
 let MetadataType;
+let MetadataSourceEnum;
 let JSONScalar;
 
-module.exports = () => [MetadataType, JSONScalar];
+module.exports = () => [MetadataType, MetadataSourceEnum, JSONScalar];
 
 JSONScalar = require('../scalars/json_scalar');
 
@@ -9,6 +10,6 @@ MetadataType = `
   type Metadata {
     id: ID!
     metadata: JSON!
-    metadata_source: String!
+    metadata_source: _MetadataSource!
   }
 `;

--- a/schema/definition/types/metadata_type.js
+++ b/schema/definition/types/metadata_type.js
@@ -1,0 +1,14 @@
+let MetadataType;
+let JSONScalar;
+
+module.exports = () => [MetadataType, JSONScalar];
+
+JSONScalar = require('../scalars/json_scalar');
+
+MetadataType = `
+  type Metadata {
+    id: ID!
+    metadata: JSON!
+    metadata_source: String!
+  }
+`;

--- a/schema/definition/types/metadata_type.js
+++ b/schema/definition/types/metadata_type.js
@@ -5,6 +5,7 @@ let JSONScalar;
 module.exports = () => [MetadataType, MetadataSourceEnum, JSONScalar];
 
 JSONScalar = require('../scalars/json_scalar');
+MetadataSourceEnum = require('../enums/metadata_source_enum');
 
 MetadataType = `
   type Metadata {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,3 +1,4 @@
+const GraphQLJSON = require('graphql-type-json');
 const { Op } = require('sequelize');
 const {
   checkUserPermissions,
@@ -447,6 +448,8 @@ module.exports = {
       return CohortUser.create({ cohort_id, user_id: user.id });
     },
   },
+
+  JSON: GraphQLJSON,
 
   User: {
     country: root => root.getCountry(),


### PR DESCRIPTION
- Add an association between `CohortChannel` and `Metadata` in the `CohortChannel` model.
- Add an association between `CohortTeam` and `Metadata` in the `CohortTeam` model.
- Add an association between `CohortUser` and `Metadata` in the `CohortUser` model.
- Add Polymorphic associations between the `Metadata` model and the related models (`CohortTeam`, `CohortUser`, & `CohortChannel`).
- Add an association between `Metadata` and `MetadataSchema`.
- Add a resolver for the `JSON` scalar type.
- Define the `JSON` scalar type in GraphQL.
- Define the `Metadata` type in GraphQL.