### PR TITLE
Create the CohortChannelUser model & associations

### DIFF
--- a/migrations/20180114212701-create-cohort-channel-user.js
+++ b/migrations/20180114212701-create-cohort-channel-user.js
@@ -1,0 +1,48 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('cohort_channel_users', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+
+    cohort_channel_id: {
+      allowNull: true,
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohort_channels',
+        key: 'id',
+      },
+    },
+
+    cohort_user_id: {
+      allowNull: true,
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohort_users',
+        key: 'id',
+      },
+    },
+
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }, {
+    uniqueKeys: [{
+      name: 'cohort_channel_users_cohort_channel-cohort_user_unique_index',
+      singleField: false,
+      fields: ['cohort_channel_id', 'cohort_user_id'],
+    }],
+  }),
+
+  down: queryInterface => queryInterface.dropTable('cohort_channel_users'),
+};

--- a/migrations/20180114213313-add_unique_constraint_to_project_skills.js
+++ b/migrations/20180114213313-add_unique_constraint_to_project_skills.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: queryInterface => queryInterface.addConstraint(
+    'project_skills',
+    ['project_id', 'skill_id'],
+    {
+      type: 'unique',
+      name: 'project_skills_project-skill_unique_index',
+    },
+  ),
+
+  down: queryInterface => queryInterface.removeConstraint(
+    'project_skills',
+    'project_skills_project-skill_unique_index',
+  ),
+};

--- a/models/cohort_channel.js
+++ b/models/cohort_channel.js
@@ -41,6 +41,10 @@ module.exports = (sequelize, DataTypes) => {
   CohortChannel.associate = (models) => {
     CohortChannel.belongsTo(models.Cohort);
     CohortChannel.hasOne(models.CohortTeam);
+    CohortChannel.belongsToMany(models.CohortUser, {
+      through: models.CohortChannelUser,
+      as: 'Members',
+    });
     CohortChannel.hasMany(models.Metadata, {
       scope: {
         entity_type: 'CohortChannel',

--- a/models/cohort_channel_user.js
+++ b/models/cohort_channel_user.js
@@ -1,0 +1,45 @@
+module.exports = (sequelize, DataTypes) => {
+  const CohortChannelUser = sequelize.define('CohortChannelUser', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+
+    cohort_channel_id: {
+      allowNull: true,
+      type: DataTypes.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohort_channels',
+        key: 'id',
+      },
+    },
+
+    cohort_user_id: {
+      allowNull: true,
+      type: DataTypes.INTEGER,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'cohort_users',
+        key: 'id',
+      },
+    },
+  });
+
+  CohortChannelUser.associate = (models) => {
+    CohortChannelUser.belongsTo(models.CohortChannel);
+    CohortChannelUser.belongsTo(models.CohortUser);
+    CohortChannelUser.hasMany(models.Metadata, {
+      scope: {
+        entity_type: 'CohortChannelUser',
+      },
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+      constraints: false,
+    });
+  };
+
+  return CohortChannelUser;
+};

--- a/models/cohort_user.js
+++ b/models/cohort_user.js
@@ -82,6 +82,10 @@ module.exports = (sequelize, DataTypes) => {
     });
     CohortUser.hasMany(models.CohortTeamCohortUser, { as: 'TeamAssociations' });
     CohortUser.hasMany(models.CohortUserStandup, { as: 'Standups' });
+    CohortUser.belongsToMany(models.CohortChannel, {
+      through: models.CohortChannelUser,
+      as: 'Channels',
+    });
     CohortUser.hasMany(models.Metadata, {
       scope: {
         entity_type: 'CohortUser',

--- a/models/metadata.js
+++ b/models/metadata.js
@@ -60,11 +60,11 @@ module.exports = (sequelize, DataTypes) => {
       targetKey: 'id',
       constraints: false,
     });
-    // Metadata.belongsTo(models.CohortChannelUser, {
-    //   foreignKey: 'entity_id',
-    //   targetKey: 'id',
-    //   constraints: false,
-    // });
+    Metadata.belongsTo(models.CohortChannelUser, {
+      foreignKey: 'entity_id',
+      targetKey: 'id',
+      constraints: false,
+    });
     Metadata.belongsTo(models.CohortTeam, {
       foreignKey: 'entity_id',
       targetKey: 'id',


### PR DESCRIPTION
- Create a migration for the `CohortChannelUser` model with a unique constraint between `cohort_channel_id` and `cohort_user_id` to ensure the logic that a user membership in a channel is not duplicated.
- Fix a mistake in the `project_skills` table by adding a unique constraint between the `project_id` and the `skill_id` to ensure that a skill is not associated with a project more than once.
- Add associations in the `CohortChannel` and `CohortUser` models to each other through the new `CohortChannelUser` model.
- Add the appropriate associations in the `CohortChannelUser` model.
- Add a polymorphic association in the `Metadata` model to the new `CohortChannelUser` model.

Closes #263