### PR TITLE
Update create cohort team mutation#312

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3675,6 +3675,11 @@
         "nopt": "3.0.6"
       }
     },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+    },
     "js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -4755,15 +4760,16 @@
       "dev": true
     },
     "pg": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.1.tgz",
-      "integrity": "sha1-PqvYygVoFEN8dp8X/3oMNqxwI8U=",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
+      "integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
       "requires": {
         "buffer-writer": "1.0.1",
+        "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "1.8.0",
-        "pg-types": "1.13.0",
+        "pg-pool": "2.0.3",
+        "pg-types": "1.12.1",
         "pgpass": "1.0.2",
         "semver": "4.3.2"
       },
@@ -4780,38 +4786,16 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
-    "pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    },
     "pg-pool": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
-      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
-      "requires": {
-        "generic-pool": "2.4.3",
-        "object-assign": "4.1.0"
-      },
-      "dependencies": {
-        "generic-pool": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-          "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8="
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-        }
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.3.tgz",
+      "integrity": "sha1-wCIDLIlJ8xKk+R+2QJzgQHa+Mlc="
     },
     "pg-types": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
-      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "requires": {
-        "pg-int8": "1.0.1",
         "postgres-array": "1.0.2",
         "postgres-bytea": "1.0.0",
         "postgres-date": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonwebtoken": "^8.1.0",
     "kue": "^0.11.6",
     "lodash": "^4.17.4",
-    "pg": "6.4.1",
+    "pg": "^7.4.1",
     "sequelize": "^4.31.0",
     "sequelize-cli": "^3.2.0",
     "slack-metadata": "^1.0.3"


### PR DESCRIPTION
reverted back to `pg 7.4.1` having removed the culprit columns in the previous PR

# refactored createCohortTeam resolver
- each creation chains into the creation of the next entry.
- allows for single mutation control over the entire cohort team creation process

## process flow:
- creates a Slack channel
- creates its cohort channel
- creates its cohort_team

## tested and debugged
### Mutation
![screen shot 2018-01-30 at 3 59 36 pm](https://user-images.githubusercontent.com/25523682/35591075-c2620c22-05d6-11e8-8066-145f62637f48.png)

### Slack channel
![screen shot 2018-01-30 at 3 54 02 pm](https://user-images.githubusercontent.com/25523682/35591080-c9d5b2ba-05d6-11e8-84c0-ba5b695bb7c0.png)

### Cohort Channel
![screen shot 2018-01-30 at 4 02 17 pm](https://user-images.githubusercontent.com/25523682/35591146-ff56451c-05d6-11e8-9643-b973dc74a308.png)

### Cohort Team
- **note** the `slack_channel_id` column is vestigial but its removal is outside of this scope

![screen shot 2018-01-30 at 4 04 09 pm](https://user-images.githubusercontent.com/25523682/35591228-3cf29d12-05d7-11e8-80d0-79b267e14290.png)

